### PR TITLE
less harsh acc_depression for streams and small buff to high density maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ output*
 expanded.rs
 .sem/
 sem_diff*
+/src/bin/
+/.cache/
+Cargo.toml
+/target_temp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ tracing = ["rosu-map/tracing"]
 divan = "0.1.21"
 rosu-map = { version = "0.2.1" }
 rosu-mods = { version = "0.4.0" }
+clap = { version = "4.5.47", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+ureq = { version = "2.12.1", default-features = true, features = ["json"] }
 
 [dev-dependencies]
 divan = { version = "0.1.21" }

--- a/src/osu_2019/difficulty_object.rs
+++ b/src/osu_2019/difficulty_object.rs
@@ -7,6 +7,7 @@ pub(crate) struct DifficultyObject<'h> {
     pub(crate) jump_dist: f32,
     pub(crate) travel_dist: f32,
     pub(crate) angle: Option<f32>,
+    pub(crate) normalised_pos: rosu_map::util::Pos,
 
     /// Angle of the movement vector (current - prev), normalised so that
     /// symmetrical vectors in any axis map to the same angle.
@@ -38,6 +39,7 @@ impl<'h> DifficultyObject<'h> {
         } else {
             ((pos - prev_cursor_pos) * scaling_factor).length()
         };
+        let normalised_pos = pos * scaling_factor;
 
         // Compute normalised vector angle if we have a previous object
         // and current is not a spinner
@@ -67,6 +69,7 @@ impl<'h> DifficultyObject<'h> {
             jump_dist,
             travel_dist,
             angle,
+            normalised_pos,
             normalised_vector_angle,
 
             delta,

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -282,11 +282,10 @@ impl<'m> OsuPP<'m> {
 
         if streams_nerf < 1.09 {
             let acc_factor = (1.0 - self.acc.unwrap()).abs();
-            acc_depression = (0.78 - acc_factor).max(0.5);
+            acc_depression = (0.86 - acc_factor).max(0.5);
 
             if acc_depression > 0.0 {
                 aim_value *= acc_depression;
-                speed_value *= acc_depression;
             }
         }
 

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -282,7 +282,7 @@ impl<'m> OsuPP<'m> {
 
         if streams_nerf < 1.09 {
             let acc_factor = (1.0 - self.acc.unwrap()).abs();
-            acc_depression = (0.86 - acc_factor).max(0.5);
+            acc_depression = (0.83 - acc_factor).max(0.5);
 
             if acc_depression > 0.0 {
                 aim_value *= acc_depression;
@@ -360,7 +360,7 @@ impl<'m> OsuPP<'m> {
         let attributes = self.attributes.as_ref().unwrap();
 
         let mut speed_value =
-            (5.0 * (attributes.speed_strain as f32 / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
+            (5.0 * (attributes.speed_strain as f32 / 0.0690).max(1.0) - 4.0).powi(3) / 100_000.0;
 
         // Shorter maps are worth less
         let mut len_bonus = 0.81
@@ -368,7 +368,7 @@ impl<'m> OsuPP<'m> {
             + (total_hits > 2000.0) as u8 as f32 * -0.1 * (total_hits / 2000.0).log10();
 
         if len_bonus > 1.0 {
-            len_bonus = len_bonus.powf(0.88);
+            len_bonus = len_bonus.powf(3.0);
         }
 
         speed_value *= len_bonus;

--- a/src/osu_2019/skill.rs
+++ b/src/osu_2019/skill.rs
@@ -73,6 +73,7 @@ impl Skill {
         // Update recent objects buffer (newest first)
         let recent = RecentObject {
             normalised_vector_angle: current.normalised_vector_angle,
+            normalised_pos: current.normalised_pos,
             strain_time: current.strain_time,
             jump_dist: current.jump_dist,
             angle: current.angle,

--- a/src/osu_2019/skill_kind.rs
+++ b/src/osu_2019/skill_kind.rs
@@ -11,6 +11,8 @@ const SPEED_BALANCING_FACTOR: f32 = 40.0;
 
 const AIM_ANGLE_BONUS_BEGIN: f32 = std::f32::consts::FRAC_PI_3;
 const TIMING_THRESHOLD: f32 = 107.0;
+const FLOW_DENSITY_TIMING_THRESHOLD: f32 = 52.0;
+const FLOW_DENSITY_MAX_BONUS: f32 = 15.0;
 
 // Angle repetition nerf constants (from kwotaq commit f3d97c08)
 const MAXIMUM_REPETITION_NERF: f32 = 0.08;
@@ -24,6 +26,7 @@ const NOTE_LIMIT: usize = 6;
 #[allow(dead_code)]
 pub(crate) struct RecentObject {
     pub(crate) normalised_vector_angle: Option<f32>,
+    pub(crate) normalised_pos: rosu_map::util::Pos,
     pub(crate) strain_time: f32,
     pub(crate) jump_dist: f32,
     pub(crate) angle: Option<f32>,
@@ -75,6 +78,7 @@ impl SkillKind {
 
                 // Penalize angle repetition (kwotaq angle repetition nerf)
                 aim_strain *= vector_angle_repetition(current, recent_objects);
+                aim_strain *= flow_density_bonus(current);
 
                 aim_strain
             }
@@ -177,8 +181,21 @@ fn vector_angle_repetition(current: &DifficultyObject<'_>, recent_objects: &[Rec
     let angle_diff_adjusted =
         (2.0 * ((curr_angle - last_angle).abs() * stack_factor).min(45.0_f32.to_radians())).cos();
 
+    // Reduce acute bonus when all three objects overlap and require little extra movement.
+    let mut overlapped_notes_weight = 1.0;
+
+    if recent_objects.len() >= 2 {
+        let prev_prev = &recent_objects[1];
+
+        let o1 = overlapness(current.normalised_pos, prev.normalised_pos);
+        let o2 = overlapness(current.normalised_pos, prev_prev.normalised_pos);
+        let o3 = overlapness(prev.normalised_pos, prev_prev.normalised_pos);
+
+        overlapped_notes_weight = 1.0 - o1 * o2 * o3;
+    }
+
     // CalcAcuteAngleBonus(lastAngle) — smoothstep from 140° to 40°
-    let acute_bonus = calc_acute_angle_bonus(last_angle);
+    let acute_bonus = calc_acute_angle_bonus(last_angle) * overlapped_notes_weight;
 
     let base_nerf = 1.0 - MAXIMUM_REPETITION_NERF * acute_bonus * angle_diff_adjusted;
 
@@ -201,6 +218,31 @@ fn smootherstep(x: f32, start: f32, end: f32) -> f32 {
 /// CalcAcuteAngleBonus — smoothstep from 140° (=0) to 40° (=1)
 fn calc_acute_angle_bonus(angle: f32) -> f32 {
     smoothstep(angle, 140.0_f32.to_radians(), 40.0_f32.to_radians())
+}
+
+/// Buff high density flow-aim patterns (fast + acute) without broadly buffing jumps.
+#[inline]
+fn flow_density_bonus(current: &DifficultyObject<'_>) -> f32 {
+    let Some(angle) = current.angle else {
+        return 1.0;
+    };
+
+    let fastness = ((FLOW_DENSITY_TIMING_THRESHOLD - current.strain_time)
+        / FLOW_DENSITY_TIMING_THRESHOLD)
+        .clamp(0.0, 1.0);
+    let acute = calc_acute_angle_bonus(angle);
+    let jump_control = (current.jump_dist / 120.0).clamp(0.0, 1.0);
+
+    1.0 + FLOW_DENSITY_MAX_BONUS * fastness * acute * jump_control
+}
+
+#[inline]
+fn overlapness(a: rosu_map::util::Pos, b: rosu_map::util::Pos) -> f32 {
+    let distance = (a - b).length();
+    let object_radius = NORMALISED_DIAMETER / 2.0;
+    let normalized = (distance - object_radius).max(0.0) / object_radius;
+
+    (1.0 - normalized * normalized).clamp(0.0, 1.0)
 }
 
 #[inline]


### PR DESCRIPTION
you can delete the shit from .gitignore and cargo.toml i suppose :clueless: since it was used for pp calc 